### PR TITLE
Use sizeof on FILE*

### DIFF
--- a/deps/src/GloVe-c/src/cooccur.c
+++ b/deps/src/GloVe-c/src/cooccur.c
@@ -254,7 +254,7 @@ int merge_files(int num) {
     CRECID *pq, new, old;
     char filename[200];
     FILE **fid, *fout;
-    fid = malloc(sizeof(FILE) * num);
+    fid = malloc(sizeof(FILE*) * num);
     pq = malloc(sizeof(CRECID) * num);
     fout = stdout;
     if (verbose > 1) fprintf(stderr, "Merging cooccurrence files: processed 0 lines.");

--- a/deps/src/GloVe-c/src/shuffle.c
+++ b/deps/src/GloVe-c/src/shuffle.c
@@ -86,7 +86,7 @@ int shuffle_merge(int num) {
     FILE **fid, *fout = stdout;
     
     array = malloc(sizeof(CREC) * array_size);
-    fid = malloc(sizeof(FILE) * num);
+    fid = malloc(sizeof(FILE*) * num);
     for (fidcounter = 0; fidcounter < num; fidcounter++) { //num = number of temporary files to merge
         sprintf(filename,"%s_%04d.bin",file_head, fidcounter);
         fid[fidcounter] = fopen(filename, "rb");


### PR DESCRIPTION
This fixes build errors on my Linux system like:

```
│ gcc src/shuffle.c -o build/shuffle -lm -pthread -Ofast -march=native -funroll-loops -Wall -Wextra -Wpedantic
│ src/shuffle.c: In function 'shuffle_merge':
│ src/shuffle.c:89:25: error: invalid application of 'sizeof' to incomplete type 'FILE'
│    89 |     fid = malloc(sizeof(FILE) * num);
│       |                         ^~~~
```